### PR TITLE
fix failed test on non x86 target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,15 +630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
  "tinyvec",
-]
-
-[[package]]
-name = "bs64"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8bebebdf2eda473523fed644eaedc4ffc43b6f35fdc6f001eb9f89dca4bd117"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]
@@ -2368,8 +2365,8 @@ dependencies = [
 name = "ore-program"
 version = "1.2.0"
 dependencies = [
+ "base64 0.22.0",
  "bs58 0.5.0",
- "bs64",
  "bytemuck",
  "mpl-token-metadata",
  "num_enum 0.7.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ static_assertions = "1.1.0"
 thiserror = "1.0.57"
 
 [dev-dependencies]
-bs64 = "0.1.2"
+base64 = "0.22.0"
 rand = "0.8.5"
 solana-program-test = "^1.16"
 solana-sdk = "^1.16"

--- a/tests/test_mine.rs
+++ b/tests/test_mine.rs
@@ -32,6 +32,11 @@ use spl_associated_token_account::{
 };
 use spl_token::state::{AccountState, Mint};
 
+use base64::{
+    Engine,
+    prelude::BASE64_STANDARD as bs64,
+};
+
 #[tokio::test]
 async fn test_mine() {
     // Setup
@@ -658,7 +663,7 @@ async fn setup_program_test_env(
             BUS_ADDRESSES[i],
             1057920,
             ore::id(),
-            bs64::encode(
+            bs64.encode(
                 &[
                     &(Bus::discriminator() as u64).to_le_bytes(),
                     Bus {
@@ -680,7 +685,7 @@ async fn setup_program_test_env(
         treasury_pda.0,
         1614720,
         ore::id(),
-        bs64::encode(
+        bs64.encode(
             &[
                 &(Treasury::discriminator() as u64).to_le_bytes(),
                 Treasury {
@@ -712,7 +717,7 @@ async fn setup_program_test_env(
         MINT_ADDRESS,
         1461600,
         spl_token::id(),
-        bs64::encode(&mint_src).as_str(),
+        bs64.encode(&mint_src).as_str(),
     );
 
     // Treasury tokens
@@ -736,7 +741,7 @@ async fn setup_program_test_env(
         tokens_address,
         2039280,
         spl_token::id(),
-        bs64::encode(&tokens_src).as_str(),
+        bs64.encode(&tokens_src).as_str(),
     );
 
     // Set sysvar

--- a/tests/test_register.rs
+++ b/tests/test_register.rs
@@ -26,6 +26,11 @@ use solana_sdk::{
 };
 use spl_token::state::{AccountState, Mint};
 
+use base64::{
+    Engine,
+    prelude::BASE64_STANDARD as bs64,
+};
+
 #[tokio::test]
 async fn test_register_account_with_lamports() {
     let (mut banks, payer, blockhash) = setup_program_test_env().await;
@@ -91,7 +96,7 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, solana_program::hash
             BUS_ADDRESSES[i],
             1057920,
             ore::id(),
-            bs64::encode(
+            bs64.encode(
                 &[
                     &(Bus::discriminator() as u64).to_le_bytes(),
                     Bus {
@@ -113,7 +118,7 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, solana_program::hash
         treasury_pda.0,
         1614720,
         ore::id(),
-        bs64::encode(
+        bs64.encode(
             &[
                 &(Treasury::discriminator() as u64).to_le_bytes(),
                 Treasury {
@@ -145,7 +150,7 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, solana_program::hash
         MINT_ADDRESS,
         1461600,
         spl_token::id(),
-        bs64::encode(&mint_src).as_str(),
+        bs64.encode(&mint_src).as_str(),
     );
 
     // Treasury tokens
@@ -169,7 +174,7 @@ async fn setup_program_test_env() -> (BanksClient, Keypair, solana_program::hash
         tokens_address,
         2039280,
         spl_token::id(),
-        bs64::encode(&tokens_src).as_str(),
+        bs64.encode(&tokens_src).as_str(),
     );
 
     // Set sysvar

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -27,6 +27,11 @@ use solana_sdk::{
 };
 use spl_token::state::{AccountState, Mint};
 
+use base64::{
+    Engine,
+    prelude::BASE64_STANDARD as bs64,
+};
+
 #[tokio::test]
 async fn test_reset() {
     // Setup
@@ -325,7 +330,7 @@ async fn setup_program_test_env(clock_state: ClockState) -> (BanksClient, Keypai
             BUS_ADDRESSES[i],
             1057920,
             ore::id(),
-            bs64::encode(
+            bs64.encode(
                 &[
                     &(Bus::discriminator() as u64).to_le_bytes(),
                     Bus {
@@ -347,7 +352,7 @@ async fn setup_program_test_env(clock_state: ClockState) -> (BanksClient, Keypai
         treasury_pda.0,
         1614720,
         ore::id(),
-        bs64::encode(
+        bs64.encode(
             &[
                 &(Treasury::discriminator() as u64).to_le_bytes(),
                 Treasury {
@@ -379,7 +384,7 @@ async fn setup_program_test_env(clock_state: ClockState) -> (BanksClient, Keypai
         MINT_ADDRESS,
         1461600,
         spl_token::id(),
-        bs64::encode(&mint_src).as_str(),
+        bs64.encode(&mint_src).as_str(),
     );
 
     // Treasury tokens
@@ -403,7 +408,7 @@ async fn setup_program_test_env(clock_state: ClockState) -> (BanksClient, Keypai
         tokens_address,
         2039280,
         spl_token::id(),
-        bs64::encode(&tokens_src).as_str(),
+        bs64.encode(&tokens_src).as_str(),
     );
 
     // Set sysvar


### PR DESCRIPTION
This pr replaced `bs64: '0.1.2'` to `base64: '0.22.0'` to ensure test is able to run on non x86 target.

The original dependency `bs64` version '0.1.2' encounters issues with its encode function due to flawed fallback logic. Specifically, when the target architecture is not x86, the macro `is_x86_feature_detected!` triggers a panic. This same behavior is observed in the decode function as well.

[entry](https://github.com/ozgb/bs64/blob/bb19d5b76eef2627bf25173bd6615ae2e42af0ab/src/lib.rs#L36-L40):
```rust
    pub fn encode(self, input: &[u8]) -> String {
        let mut output = vec![0u8; encode_len(input.len())];
        avx2::encode_with_fallback(&mut output, input);
        unsafe { String::from_utf8_unchecked(output) }
    }
```
[impl](https://github.com/ozgb/bs64/blob/bb19d5b76eef2627bf25173bd6615ae2e42af0ab/src/avx2/mod.rs#L72-L78):
```rust
pub fn encode_with_fallback(dest: &mut [u8], str: &[u8]) -> usize {
    if is_x86_feature_detected!("avx2") {
        unsafe { encode(dest, str) }
    } else {
        simple::encode(str, dest)
    }
}
```

error:

```
error: This macro cannot be used on the current target.
                                   You can prevent it from being used in other architectures by
                                   guarding it behind a cfg(any(target_arch = "x86", target_arch = "x86_64")).
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bs64-0.1.2/src/avx2/mod.rs:73:8
   |
73 |     if is_x86_feature_detected!("avx2") {
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `is_x86_feature_detected` (in Nightly builds, run with -Z macro-backtrace for more info)

error: This macro cannot be used on the current target.
                                   You can prevent it from being used in other architectures by
                                   guarding it behind a cfg(any(target_arch = "x86", target_arch = "x86_64")).
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bs64-0.1.2/src/avx2/mod.rs:159:8
    |
159 |     if is_x86_feature_detected!("avx2") {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `is_x86_feature_detected` (in Nightly builds, run with -Z macro-backtrace for more info)

```
