### PR TITLE
Rewards vesting

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -21,6 +21,9 @@ pub const ONE_ORE: u64 = 10u64.pow(TOKEN_DECIMALS as u32);
 /// The duration of one minute, in seconds.
 pub const ONE_MINUTE: i64 = 60;
 
+/// The duration of one hour, in seconds.
+pub const ONE_HOUR: i64 = 3600;
+
 /// The duration of one day, in seconds.
 pub const ONE_DAY: i64 = 86400;
 

--- a/src/processor/claim.rs
+++ b/src/processor/claim.rs
@@ -51,7 +51,7 @@ pub fn process_claim<'a, 'info>(
     let mut proof_data = proof_info.data.borrow_mut();
     let proof = Proof::try_from_bytes_mut(&mut proof_data)?;
     let clock = Clock::get().or(Err(ProgramError::InvalidAccountData))?;
-    vest_rewards(clock, proof);
+    vest_rewards(&clock, proof);
 
     // Update proof balance
     proof.balance = proof

--- a/src/processor/mine.rs
+++ b/src/processor/mine.rs
@@ -159,7 +159,7 @@ pub fn process_mine<'a, 'info>(
     let reward_actual = reward.min(bus.rewards);
 
     // Vest rewards
-    vest_rewards(clock, proof);
+    vest_rewards(&clock, proof);
 
     // Update balances
     sol_log(&format!("Total {}", reward));
@@ -196,7 +196,7 @@ pub fn process_mine<'a, 'info>(
     Ok(())
 }
 
-pub fn vest_rewards(clock: Clock, proof: &mut Proof) {
+pub fn vest_rewards(clock: &Clock, proof: &mut Proof) {
     let hours_since_vest = clock
         .unix_timestamp
         .saturating_sub(proof.last_vest_at)

--- a/src/processor/register.rs
+++ b/src/processor/register.rs
@@ -72,11 +72,12 @@ pub fn process_register<'a, 'info>(
         &slot_hashes_info.data.borrow()[0..size_of::<SlotHash>()],
     ])
     .0;
-    proof.last_claim_at = clock.unix_timestamp;
     proof.last_hash_at = clock.unix_timestamp;
     proof.last_stake_at = clock.unix_timestamp;
+    proof.last_vest_at = clock.unix_timestamp;
     proof.total_hashes = 0;
     proof.total_rewards = 0;
+    proof.vesting = [0; 25];
 
     Ok(())
 }

--- a/src/state/proof.rs
+++ b/src/state/proof.rs
@@ -21,20 +21,23 @@ pub struct Proof {
     /// The current mining challenge.
     pub challenge: [u8; 32],
 
-    /// The last time this account claimed rewards.
-    pub last_claim_at: i64,
-
     /// The last time this account provided a hash.
     pub last_hash_at: i64,
 
     /// The last time stake was deposited into this account.
     pub last_stake_at: i64,
 
+    /// The last time this account vested.
+    pub last_vest_at: i64,
+
     /// The total lifetime hashes provided by this miner.
     pub total_hashes: u64,
 
     /// The total lifetime rewards distributed to this miner.
     pub total_rewards: u64,
+
+    /// The hourly vesting status of rewards.
+    pub vesting: [u64; 25],
 }
 
 impl Discriminator for Proof {


### PR DESCRIPTION
The current claims rate limiter can easily be sybil attacked to avoid burn. The goal of the rate limiter was to require that miners should have to take on at least 1 day of price exposure to their mining rewards before they can sell. This would be better achieved through a vesting schedule. 

In this pr, I've introduced an hourly vesting schedule as a `[u64; 25]` type on the proof account. A miner receives rewards in the `[0]` slot and every hour they move forward one position in the array through the `vest_rewards` function (done as part of every `mine` and `claim`). 

Only rewards in the `[24]` slot are considered fully vested and may be claimed.  