### PR TITLE
Introduce miner authority

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -214,12 +214,13 @@ pub fn reset(signer: Pubkey) -> Instruction {
 }
 
 /// Builds an open instruction.
-pub fn open(signer: Pubkey) -> Instruction {
+pub fn open(signer: Pubkey, miner: Pubkey) -> Instruction {
     let proof_pda = Pubkey::find_program_address(&[PROOF, signer.as_ref()], &crate::id());
     Instruction {
         program_id: crate::id(),
         accounts: vec![
             AccountMeta::new(signer, true),
+            AccountMeta::new(miner, true),
             AccountMeta::new(proof_pda.0, false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(sysvar::slot_hashes::id(), false),

--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -160,6 +160,39 @@ pub fn load_proof<'a, 'info>(
 
 /// Errors if:
 /// - Owner is not Ore program.
+/// - Data is empty.
+/// - Data cannot deserialize into a proof account.
+/// - Proof miner does not match the expected address.
+/// - Expected to be writable, but is not.
+pub fn load_proof_with_miner<'a, 'info>(
+    info: &'a AccountInfo<'info>,
+    miner: &Pubkey,
+    is_writable: bool,
+) -> Result<(), ProgramError> {
+    if info.owner.ne(&crate::id()) {
+        return Err(ProgramError::InvalidAccountOwner);
+    }
+
+    if info.data_is_empty() {
+        return Err(ProgramError::UninitializedAccount);
+    }
+
+    let proof_data = info.data.borrow();
+    let proof = Proof::try_from_bytes(&proof_data)?;
+
+    if proof.miner.ne(&miner) {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    if is_writable && !info.is_writable {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    Ok(())
+}
+
+/// Errors if:
+/// - Owner is not Ore program.
 /// - Address does not match the expected address.
 /// - Data is empty.
 /// - Data cannot deserialize into a treasury account.

--- a/src/processor/mine.rs
+++ b/src/processor/mine.rs
@@ -57,7 +57,7 @@ pub fn process_mine<'a, 'info>(
     load_signer(signer)?;
     load_any_bus(bus_info, true)?;
     load_config(config_info, false)?;
-    load_proof(proof_info, signer.key, true)?;
+    load_proof_with_miner(proof_info, signer.key, true)?;
     load_sysvar(instructions_sysvar, sysvar::instructions::id())?;
     load_sysvar(slot_hashes_sysvar, sysvar::slot_hashes::id())?;
 

--- a/src/processor/open.rs
+++ b/src/processor/open.rs
@@ -39,10 +39,11 @@ pub fn process_open<'a, 'info>(
     let args = OpenArgs::try_from_bytes(data)?;
 
     // Load accounts
-    let [signer, proof_info, system_program, slot_hashes_info] = accounts else {
+    let [signer, miner_info, proof_info, system_program, slot_hashes_info] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
     load_signer(signer)?;
+    load_signer(miner_info)?;
     load_uninitialized_pda(
         proof_info,
         &[PROOF, signer.key.as_ref()],
@@ -75,6 +76,7 @@ pub fn process_open<'a, 'info>(
     proof.last_hash = [0; 32];
     proof.last_hash_at = clock.unix_timestamp;
     proof.last_stake_at = clock.unix_timestamp;
+    proof.miner = *miner_info.key;
     proof.total_hashes = 0;
     proof.total_rewards = 0;
 

--- a/src/state/proof.rs
+++ b/src/state/proof.rs
@@ -30,6 +30,9 @@ pub struct Proof {
     /// The last time stake was deposited into this account.
     pub last_stake_at: i64,
 
+    /// The keypair which can submit hashes for mining.
+    pub miner: Pubkey,
+
     /// The total lifetime hashes provided by this miner.
     pub total_hashes: u64,
 

--- a/src/state/proof.rs
+++ b/src/state/proof.rs
@@ -30,7 +30,7 @@ pub struct Proof {
     /// The last time stake was deposited into this account.
     pub last_stake_at: i64,
 
-    /// The keypair which can submit hashes for mining.
+    /// The keypair which has permission to submit hashes for mining.
     pub miner: Pubkey,
 
     /// The total lifetime hashes provided by this miner.


### PR DESCRIPTION
- Introduces `miner` authority with permissions to submit hashes
- Allows stake to be secured by pda/multisig