### PR TITLE
fix claim tx failure in corner case

### DIFF
--- a/program/src/claim.rs
+++ b/program/src/claim.rs
@@ -40,10 +40,10 @@ pub fn process_claim<'a, 'info>(
     // Update miner balance
     let mut proof_data = proof_info.data.borrow_mut();
     let proof = Proof::try_from_bytes_mut(&mut proof_data)?;
-    proof.balance = proof
-        .balance
-        .checked_sub(amount)
-        .ok_or(OreError::ClaimTooLarge)?;
+
+    if proof.balance < amount {
+        return Err(OreError::ClaimTooLarge.into());
+    }
 
     // Distribute tokens from treasury to beneficiary
     transfer_signed(
@@ -54,6 +54,11 @@ pub fn process_claim<'a, 'info>(
         amount,
         &[&[TREASURY, &[TREASURY_BUMP]]],
     )?;
+
+    proof.balance = proof
+        .balance
+        .checked_sub(amount)
+        .ok_or(OreError::ClaimTooLarge)?;
 
     Ok(())
 }


### PR DESCRIPTION
Corner case description:
a) When a CPI error occurs, the entire transaction is aborted immediately, which may cause potential state inconsistency.
b) The probability of a subtract operation failure is much lower than the failure of the transfer CPI call.
c) Subtract balance after successful transfer may be better since we can't really handle the error from invoke or invoke_signed.

Proposed solution: swap the execution order of balance subtract and transfer CPI