### PR TITLE
move spam rejection earlier to reduce cu usage

### DIFF
--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -86,6 +86,14 @@ pub fn process_mine<'a, 'info>(
         return Err(OreError::HashInvalid.into());
     }
 
+    // Reject spam transactions.
+    let t: i64 = clock.unix_timestamp;
+    let t_target = proof.last_hash_at.saturating_add(ONE_MINUTE);
+    let t_spam = t_target.saturating_sub(TOLERANCE);
+    if t.lt(&t_spam) {
+        return Err(OreError::Spam.into());
+    }
+
     // Validate hash satisfies the minimnum difficulty.
     let hash = solution.to_hash();
     let difficulty = hash.difficulty();
@@ -102,7 +110,6 @@ pub fn process_mine<'a, 'info>(
     // If user has greater than or equal to the max stake on the network, they receive 2x multiplier.
     // Any stake less than this will receives between 1x and 2x multipler. The multipler is only active
     // if the miner's last stake deposit was more than one minute ago.
-    let t = clock.unix_timestamp;
     if config.max_stake.gt(&0) && proof.last_stake_at.saturating_add(ONE_MINUTE).le(&t) {
         let staking_reward = (reward as u128)
             .checked_mul(proof.balance.min(config.max_stake) as u128)
@@ -110,13 +117,6 @@ pub fn process_mine<'a, 'info>(
             .checked_div(config.max_stake as u128)
             .unwrap() as u64;
         reward = reward.checked_add(staking_reward).unwrap();
-    }
-
-    // Reject spam transactions.
-    let t_target = proof.last_hash_at.saturating_add(ONE_MINUTE);
-    let t_spam = t_target.saturating_sub(TOLERANCE);
-    if t.lt(&t_spam) {
-        return Err(OreError::Spam.into());
     }
 
     // Apply liveness penalty.


### PR DESCRIPTION
It is possible to move the spam rejection earlier in the code to avoid using unnecessary CUs