### PR TITLE
Make min difficulty algorithmic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ const-crypto = "0.1.0"
 drillx = { version = "2.0.0-beta.1", features = ["solana"] }
 mpl-token-metadata = "4.1.2"
 num_enum = "0.7.2"
-ore-api = { path = "api", version = "2.0.0-beta.2" }
-ore-utils = { path = "utils", version = "2.0.0-beta.2", features = ["spl"] }
+ore-api = { path = "api", version = "2.0.0-beta.3" }
+ore-utils = { path = "utils", version = "2.0.0-beta.3", features = ["spl"] }
 shank = "0.3.0"
 solana-program = "^1.18"
 spl-token = { version = "^4", features = ["no-entrypoint"] }

--- a/api/src/consts.rs
+++ b/api/src/consts.rs
@@ -5,22 +5,20 @@ use solana_program::{pubkey, pubkey::Pubkey};
 /// The admin allowed to initialize the program.
 pub const ADMIN: Pubkey = pubkey!("HBUh9g46wk2X89CvaNN15UmsznP59rh6od1h8JwYAopk");
 
-/// The reward rate to intialize the program with.
-pub const INITIAL_BASE_REWARD_RATE: u64 = 2u64.pow(25); // 10u64.pow(3u32);
+/// The base reward rate to intialize the program with.
+pub const INITIAL_BASE_REWARD_RATE: u64 = 2u64.pow(10);
 
-/// The minimum threshold for the base reward rate, at which point the min difficulty should be increased
-// TODO 2^8 (0.00000000256)
-pub const BASE_REWARD_RATE_MIN_THRESHOLD: u64 = 2u64.pow(24);
+/// The minimum allowed base reward rate, at which point the min difficulty should be increased
+pub const BASE_REWARD_RATE_MIN_THRESHOLD: u64 = 2;
 
-/// The maximum threshold for the base reward rate, at which point the min difficulty should be decreased.
-// TODO 2^32 (0.04294967296)
-pub const BASE_REWARD_RATE_MAX_THRESHOLD: u64 = 2u64.pow(26);
+/// The maximum allowed base reward rate, at which point the min difficulty should be decreased.
+pub const BASE_REWARD_RATE_MAX_THRESHOLD: u64 = 2u64.pow(24);
 
 /// The spam/liveness tolerance in seconds.
 pub const TOLERANCE: i64 = 5;
 
 /// The minimum difficulty to initialize the program with.
-pub const INITIAL_MIN_DIFFICULTY: u32 = 0; // 8;
+pub const INITIAL_MIN_DIFFICULTY: u32 = 0;
 
 /// The decimal precision of the ORE token.
 /// There are 100 billion indivisible units per ORE (called "grains").

--- a/api/src/consts.rs
+++ b/api/src/consts.rs
@@ -2,8 +2,8 @@ use array_const_fn_init::array_const_fn_init;
 use const_crypto::ed25519;
 use solana_program::{pubkey, pubkey::Pubkey};
 
-/// The admin allowed to initialize the program.
-pub const ADMIN: Pubkey = pubkey!("HBUh9g46wk2X89CvaNN15UmsznP59rh6od1h8JwYAopk");
+/// The authority allowed to initialize the program.
+pub const INITIALIZER_ADDRESS: Pubkey = pubkey!("HBUh9g46wk2X89CvaNN15UmsznP59rh6od1h8JwYAopk");
 
 /// The base reward rate to intialize the program with.
 pub const INITIAL_BASE_REWARD_RATE: u64 = 2u64.pow(6);

--- a/api/src/consts.rs
+++ b/api/src/consts.rs
@@ -6,19 +6,19 @@ use solana_program::{pubkey, pubkey::Pubkey};
 pub const ADMIN: Pubkey = pubkey!("HBUh9g46wk2X89CvaNN15UmsznP59rh6od1h8JwYAopk");
 
 /// The base reward rate to intialize the program with.
-pub const INITIAL_BASE_REWARD_RATE: u64 = 2u64.pow(10);
+pub const INITIAL_BASE_REWARD_RATE: u64 = 2u64.pow(6);
 
 /// The minimum allowed base reward rate, at which point the min difficulty should be increased
-pub const BASE_REWARD_RATE_MIN_THRESHOLD: u64 = 2;
+pub const BASE_REWARD_RATE_MIN_THRESHOLD: u64 = 2u64.pow(5);
 
 /// The maximum allowed base reward rate, at which point the min difficulty should be decreased.
-pub const BASE_REWARD_RATE_MAX_THRESHOLD: u64 = 2u64.pow(24);
+pub const BASE_REWARD_RATE_MAX_THRESHOLD: u64 = 2u64.pow(8);
 
 /// The spam/liveness tolerance in seconds.
 pub const TOLERANCE: i64 = 5;
 
 /// The minimum difficulty to initialize the program with.
-pub const INITIAL_MIN_DIFFICULTY: u32 = 0;
+pub const INITIAL_MIN_DIFFICULTY: u32 = 8;
 
 /// The decimal precision of the ORE token.
 /// There are 100 billion indivisible units per ORE (called "grains").

--- a/api/src/consts.rs
+++ b/api/src/consts.rs
@@ -2,17 +2,25 @@ use array_const_fn_init::array_const_fn_init;
 use const_crypto::ed25519;
 use solana_program::{pubkey, pubkey::Pubkey};
 
-/// The reward rate to intialize the program with.
-pub const INITIAL_BASE_REWARD_RATE: u64 = 10u64.pow(3u32);
-
 /// The admin allowed to initialize the program.
-pub const INITIAL_ADMIN: Pubkey = pubkey!("HBUh9g46wk2X89CvaNN15UmsznP59rh6od1h8JwYAopk");
+pub const ADMIN: Pubkey = pubkey!("HBUh9g46wk2X89CvaNN15UmsznP59rh6od1h8JwYAopk");
+
+/// The reward rate to intialize the program with.
+pub const INITIAL_BASE_REWARD_RATE: u64 = 2u64.pow(25); // 10u64.pow(3u32);
+
+/// The minimum threshold for the base reward rate, at which point the min difficulty should be increased
+// TODO 2^8 (0.00000000256)
+pub const BASE_REWARD_RATE_MIN_THRESHOLD: u64 = 2u64.pow(24);
+
+/// The maximum threshold for the base reward rate, at which point the min difficulty should be decreased.
+// TODO 2^32 (0.04294967296)
+pub const BASE_REWARD_RATE_MAX_THRESHOLD: u64 = 2u64.pow(26);
 
 /// The spam/liveness tolerance in seconds.
 pub const TOLERANCE: i64 = 5;
 
-/// The minimum difficulty required of all submitted hashes.
-pub const MIN_DIFFICULTY: u32 = 8;
+/// The minimum difficulty to initialize the program with.
+pub const INITIAL_MIN_DIFFICULTY: u32 = 0; // 8;
 
 /// The decimal precision of the ORE token.
 /// There are 100 billion indivisible units per ORE (called "grains").

--- a/api/src/state/config.rs
+++ b/api/src/state/config.rs
@@ -10,20 +10,20 @@ use super::AccountDiscriminator;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Pod, ShankAccount, Zeroable)]
 pub struct Config {
-    // TODO Remove this
-    pub admin: Pubkey,
-
     /// The base reward rate paid out for a hash of minimum difficulty.
     pub base_reward_rate: u64,
 
     /// The timestamp of the last reset.
     pub last_reset_at: i64,
 
-    /// The largest known stake balance on the network.
-    pub max_stake: u64,
+    /// The minimum accepted difficulty.
+    pub min_difficulty: u64,
 
     /// The address of the proof account with the highest stake balance.
     pub top_staker: Pubkey,
+
+    /// The largest known stake balance on the network.
+    pub top_staker_balance: u64,
 }
 
 impl Discriminator for Config {

--- a/program/src/crown.rs
+++ b/program/src/crown.rs
@@ -56,8 +56,8 @@ pub fn process_crown<'a, 'info>(
     }
 
     // Crown the new top staker.
-    config.max_stake = proof_new.balance;
     config.top_staker = *proof_new_info.key;
+    config.top_staker_balance = proof_new.balance;
 
     Ok(())
 }

--- a/program/src/initialize.rs
+++ b/program/src/initialize.rs
@@ -91,7 +91,7 @@ pub fn process_initialize<'a, 'info>(
     load_sysvar(rent_sysvar, sysvar::rent::id())?;
 
     // Check signer
-    if signer.key.ne(&ADMIN) {
+    if signer.key.ne(&INITIALIZER_ADDRESS) {
         return Err(ProgramError::MissingRequiredSignature);
     }
 

--- a/program/src/initialize.rs
+++ b/program/src/initialize.rs
@@ -91,7 +91,7 @@ pub fn process_initialize<'a, 'info>(
     load_sysvar(rent_sysvar, sysvar::rent::id())?;
 
     // Check signer
-    if signer.key.ne(&INITIAL_ADMIN) {
+    if signer.key.ne(&ADMIN) {
         return Err(ProgramError::MissingRequiredSignature);
     }
 
@@ -140,7 +140,7 @@ pub fn process_initialize<'a, 'info>(
     let config = Config::try_from_bytes_mut(&mut config_data)?;
     config.base_reward_rate = INITIAL_BASE_REWARD_RATE;
     config.last_reset_at = 0;
-    config.min_difficulty = MIN_DIFFICULTY as u64;
+    config.min_difficulty = INITIAL_MIN_DIFFICULTY as u64;
     config.top_staker = Pubkey::new_from_array([0; 32]);
     config.top_staker_balance = 0;
 

--- a/program/src/initialize.rs
+++ b/program/src/initialize.rs
@@ -140,8 +140,9 @@ pub fn process_initialize<'a, 'info>(
     let config = Config::try_from_bytes_mut(&mut config_data)?;
     config.base_reward_rate = INITIAL_BASE_REWARD_RATE;
     config.last_reset_at = 0;
-    config.max_stake = 0;
+    config.min_difficulty = MIN_DIFFICULTY as u64;
     config.top_staker = Pubkey::new_from_array([0; 32]);
+    config.top_staker_balance = 0;
 
     // Initialize treasury
     create_pda(

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -115,7 +115,7 @@ pub fn process_mine<'a, 'info>(
     // If user has greater than or equal to the max stake on the network, they receive 2x multiplier.
     // Any stake less than this will receives between 1x and 2x multipler. The multipler is only active
     // if the miner's last stake deposit was more than one minute ago.
-    if config.max_stake.gt(&0) 
+    if config.top_staker_balance.gt(&0)
         && proof.balance.gt(&0)
         && proof.last_stake_at.saturating_add(ONE_MINUTE).le(&t)
     {

--- a/program/src/reset.rs
+++ b/program/src/reset.rs
@@ -172,7 +172,8 @@ mod tests {
 
     use crate::calculate_new_reward_rate;
     use ore_api::consts::{
-        BUS_EPOCH_REWARDS, MAX_EPOCH_REWARDS, SMOOTHING_FACTOR, TARGET_EPOCH_REWARDS,
+        BASE_REWARD_RATE_MIN_THRESHOLD, BUS_EPOCH_REWARDS, MAX_EPOCH_REWARDS, SMOOTHING_FACTOR,
+        TARGET_EPOCH_REWARDS,
     };
 
     const FUZZ_SIZE: u64 = 10_000;
@@ -198,6 +199,13 @@ mod tests {
             current_rate,
             TARGET_EPOCH_REWARDS.saturating_add(1_000_000_000),
         );
+        assert!(new_rate.lt(&current_rate));
+    }
+
+    #[test]
+    fn test_calculate_new_reward_rate_lower_edge() {
+        let current_rate = BASE_REWARD_RATE_MIN_THRESHOLD;
+        let new_rate = calculate_new_reward_rate(current_rate, TARGET_EPOCH_REWARDS + 1);
         assert!(new_rate.lt(&current_rate));
     }
 


### PR DESCRIPTION
- If the min difficulty is constant, we potentially run into an issue longterm where base reward rate can't go lower (at 1 atomic unit) but global hashpower is large enough to exceed the 1 ore/min supply function.
- This pr sets a valid range for the base reward rate. If the base reward rate breaks this range, we increment or decrement the min difficulty accordingly. 