### PR TITLE
Fix warning raised by cargo clippy (rust linter)

### DIFF
--- a/api/src/loaders.rs
+++ b/api/src/loaders.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// Errors if:
 /// - Account is not a signer.
-pub fn load_signer<'a, 'info>(info: &'a AccountInfo<'info>) -> Result<(), ProgramError> {
+pub fn load_signer(info: &AccountInfo<'_>) -> Result<(), ProgramError> {
     if !info.is_signer {
         return Err(ProgramError::MissingRequiredSignature);
     }
@@ -27,11 +27,7 @@ pub fn load_signer<'a, 'info>(info: &'a AccountInfo<'info>) -> Result<(), Progra
 /// - Data cannot deserialize into a bus account.
 /// - Bus ID does not match the expected ID.
 /// - Expected to be writable, but is not.
-pub fn load_bus<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    id: u64,
-    is_writable: bool,
-) -> Result<(), ProgramError> {
+pub fn load_bus(info: &AccountInfo<'_>, id: u64, is_writable: bool) -> Result<(), ProgramError> {
     if info.owner.ne(&crate::id()) {
         return Err(ProgramError::InvalidAccountOwner);
     }
@@ -65,10 +61,7 @@ pub fn load_bus<'a, 'info>(
 /// - Bus ID is not in the expected range.
 /// - Address is not in set of valid bus address.
 /// - Expected to be writable, but is not.
-pub fn load_any_bus<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    is_writable: bool,
-) -> Result<(), ProgramError> {
+pub fn load_any_bus(info: &AccountInfo<'_>, is_writable: bool) -> Result<(), ProgramError> {
     if info.owner.ne(&crate::id()) {
         return Err(ProgramError::InvalidAccountOwner);
     }
@@ -77,7 +70,7 @@ pub fn load_any_bus<'a, 'info>(
         return Err(ProgramError::UninitializedAccount);
     }
 
-    if info.data.borrow()[0].ne(&(Bus::discriminator() as u8)) {
+    if info.data.borrow()[0].ne(&(Bus::discriminator())) {
         return Err(solana_program::program_error::ProgramError::InvalidAccountData);
     }
 
@@ -98,10 +91,7 @@ pub fn load_any_bus<'a, 'info>(
 /// - Data is empty.
 /// - Data cannot deserialize into a config account.
 /// - Expected to be writable, but is not.
-pub fn load_config<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    is_writable: bool,
-) -> Result<(), ProgramError> {
+pub fn load_config(info: &AccountInfo<'_>, is_writable: bool) -> Result<(), ProgramError> {
     if info.owner.ne(&crate::id()) {
         return Err(ProgramError::InvalidAccountOwner);
     }
@@ -114,7 +104,7 @@ pub fn load_config<'a, 'info>(
         return Err(ProgramError::UninitializedAccount);
     }
 
-    if info.data.borrow()[0].ne(&(Config::discriminator() as u8)) {
+    if info.data.borrow()[0].ne(&(Config::discriminator())) {
         return Err(solana_program::program_error::ProgramError::InvalidAccountData);
     }
 
@@ -131,8 +121,8 @@ pub fn load_config<'a, 'info>(
 /// - Data cannot deserialize into a proof account.
 /// - Proof authority does not match the expected address.
 /// - Expected to be writable, but is not.
-pub fn load_proof<'a, 'info>(
-    info: &'a AccountInfo<'info>,
+pub fn load_proof(
+    info: &AccountInfo<'_>,
     authority: &Pubkey,
     is_writable: bool,
 ) -> Result<(), ProgramError> {
@@ -147,7 +137,7 @@ pub fn load_proof<'a, 'info>(
     let proof_data = info.data.borrow();
     let proof = Proof::try_from_bytes(&proof_data)?;
 
-    if proof.authority.ne(&authority) {
+    if proof.authority.ne(authority) {
         return Err(ProgramError::InvalidAccountData);
     }
 
@@ -164,8 +154,8 @@ pub fn load_proof<'a, 'info>(
 /// - Data cannot deserialize into a proof account.
 /// - Proof miner does not match the expected address.
 /// - Expected to be writable, but is not.
-pub fn load_proof_with_miner<'a, 'info>(
-    info: &'a AccountInfo<'info>,
+pub fn load_proof_with_miner(
+    info: &AccountInfo<'_>,
     miner: &Pubkey,
     is_writable: bool,
 ) -> Result<(), ProgramError> {
@@ -180,7 +170,7 @@ pub fn load_proof_with_miner<'a, 'info>(
     let proof_data = info.data.borrow();
     let proof = Proof::try_from_bytes(&proof_data)?;
 
-    if proof.miner.ne(&miner) {
+    if proof.miner.ne(miner) {
         return Err(ProgramError::InvalidAccountData);
     }
 
@@ -196,10 +186,7 @@ pub fn load_proof_with_miner<'a, 'info>(
 /// - Data is empty.
 /// - Data cannot deserialize into a proof account.
 /// - Expected to be writable, but is not.
-pub fn load_any_proof<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    is_writable: bool,
-) -> Result<(), ProgramError> {
+pub fn load_any_proof(info: &AccountInfo<'_>, is_writable: bool) -> Result<(), ProgramError> {
     if info.owner.ne(&crate::id()) {
         return Err(ProgramError::InvalidAccountOwner);
     }
@@ -208,7 +195,7 @@ pub fn load_any_proof<'a, 'info>(
         return Err(ProgramError::UninitializedAccount);
     }
 
-    if info.data.borrow()[0].ne(&(Proof::discriminator() as u8)) {
+    if info.data.borrow()[0].ne(&(Proof::discriminator())) {
         return Err(solana_program::program_error::ProgramError::InvalidAccountData);
     }
 
@@ -225,10 +212,7 @@ pub fn load_any_proof<'a, 'info>(
 /// - Data is empty.
 /// - Data cannot deserialize into a treasury account.
 /// - Expected to be writable, but is not.
-pub fn load_treasury<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    is_writable: bool,
-) -> Result<(), ProgramError> {
+pub fn load_treasury(info: &AccountInfo<'_>, is_writable: bool) -> Result<(), ProgramError> {
     if info.owner.ne(&crate::id()) {
         return Err(ProgramError::InvalidAccountOwner);
     }
@@ -241,7 +225,7 @@ pub fn load_treasury<'a, 'info>(
         return Err(ProgramError::UninitializedAccount);
     }
 
-    if info.data.borrow()[0].ne(&(Treasury::discriminator() as u8)) {
+    if info.data.borrow()[0].ne(&(Treasury::discriminator())) {
         return Err(solana_program::program_error::ProgramError::InvalidAccountData);
     }
 
@@ -255,10 +239,7 @@ pub fn load_treasury<'a, 'info>(
 /// Errors if:
 /// - Address does not match the expected treasury tokens address.
 /// - Cannot load as a token account
-pub fn load_treasury_tokens<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    is_writable: bool,
-) -> Result<(), ProgramError> {
+pub fn load_treasury_tokens(info: &AccountInfo<'_>, is_writable: bool) -> Result<(), ProgramError> {
     if info.key.ne(&TREASURY_TOKENS_ADDRESS) {
         return Err(ProgramError::InvalidSeeds);
     }
@@ -272,8 +253,8 @@ pub fn load_treasury_tokens<'a, 'info>(
 /// - Data is empty.
 /// - Data cannot deserialize into a mint account.
 /// - Expected to be writable, but is not.
-pub fn load_mint<'a, 'info>(
-    info: &'a AccountInfo<'info>,
+pub fn load_mint(
+    info: &AccountInfo<'_>,
     address: Pubkey,
     is_writable: bool,
 ) -> Result<(), ProgramError> {
@@ -305,8 +286,8 @@ pub fn load_mint<'a, 'info>(
 /// - Token account owner does not match the expected owner address.
 /// - Token account mint does not match the expected mint address.
 /// - Expected to be writable, but is not.
-pub fn load_token_account<'a, 'info>(
-    info: &'a AccountInfo<'info>,
+pub fn load_token_account(
+    info: &AccountInfo<'_>,
     owner: Option<&Pubkey>,
     mint: &Pubkey,
     is_writable: bool,
@@ -322,7 +303,7 @@ pub fn load_token_account<'a, 'info>(
     let account_data = info.data.borrow();
     let account = spl_token::state::Account::unpack(&account_data)?;
 
-    if account.mint.ne(&mint) {
+    if account.mint.ne(mint) {
         return Err(ProgramError::InvalidAccountData);
     }
 
@@ -342,8 +323,8 @@ pub fn load_token_account<'a, 'info>(
 /// Errors if:
 /// - Address does not match PDA derived from provided seeds.
 /// - Cannot load as an uninitialized account.
-pub fn load_uninitialized_pda<'a, 'info>(
-    info: &'a AccountInfo<'info>,
+pub fn load_uninitialized_pda(
+    info: &AccountInfo<'_>,
     seeds: &[&[u8]],
     bump: u8,
     program_id: &Pubkey,
@@ -365,10 +346,7 @@ pub fn load_uninitialized_pda<'a, 'info>(
 /// - Owner is not the system program.
 /// - Data is not empty.
 /// - Account is not writable.
-pub fn load_system_account<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    is_writable: bool,
-) -> Result<(), ProgramError> {
+pub fn load_system_account(info: &AccountInfo<'_>, is_writable: bool) -> Result<(), ProgramError> {
     if info.owner.ne(&system_program::id()) {
         return Err(ProgramError::InvalidAccountOwner);
     }
@@ -387,10 +365,7 @@ pub fn load_system_account<'a, 'info>(
 /// Errors if:
 /// - Owner is not the sysvar address.
 /// - Account cannot load with the expected address.
-pub fn load_sysvar<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    key: Pubkey,
-) -> Result<(), ProgramError> {
+pub fn load_sysvar(info: &AccountInfo<'_>, key: Pubkey) -> Result<(), ProgramError> {
     if info.owner.ne(&sysvar::id()) {
         return Err(ProgramError::InvalidAccountOwner);
     }
@@ -401,8 +376,8 @@ pub fn load_sysvar<'a, 'info>(
 /// Errors if:
 /// - Address does not match the expected value.
 /// - Expected to be writable, but is not.
-pub fn load_account<'a, 'info>(
-    info: &'a AccountInfo<'info>,
+pub fn load_account(
+    info: &AccountInfo<'_>,
     key: Pubkey,
     is_writable: bool,
 ) -> Result<(), ProgramError> {
@@ -420,10 +395,7 @@ pub fn load_account<'a, 'info>(
 /// Errors if:
 /// - Address does not match the expected value.
 /// - Account is not executable.
-pub fn load_program<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    key: Pubkey,
-) -> Result<(), ProgramError> {
+pub fn load_program(info: &AccountInfo<'_>, key: Pubkey) -> Result<(), ProgramError> {
     if info.key.ne(&key) {
         return Err(ProgramError::IncorrectProgramId);
     }
@@ -437,10 +409,7 @@ pub fn load_program<'a, 'info>(
 
 /// Errors if:
 /// - Account is not writable.
-pub fn load_any<'a, 'info>(
-    info: &'a AccountInfo<'info>,
-    is_writable: bool,
-) -> Result<(), ProgramError> {
+pub fn load_any(info: &AccountInfo<'_>, is_writable: bool) -> Result<(), ProgramError> {
     if is_writable && !info.is_writable {
         return Err(ProgramError::InvalidAccountData);
     }

--- a/program/src/claim.rs
+++ b/program/src/claim.rs
@@ -7,7 +7,7 @@ use solana_program::{
 use crate::utils::AccountDeserialize;
 
 /// Claim distributes claimable ORE from the treasury to a miner.
-pub fn process_claim<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
+pub fn process_claim(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
     // Parse args.
     let args = ClaimArgs::try_from_bytes(data)?;
     let amount = u64::from_le_bytes(args.amount);

--- a/program/src/close.rs
+++ b/program/src/close.rs
@@ -7,7 +7,7 @@ use solana_program::{
 use crate::utils::AccountDeserialize;
 
 /// Close closes a proof account and returns the rent to the owner.
-pub fn process_close<'a, 'info>(accounts: &'a [AccountInfo<'info>], _data: &[u8]) -> ProgramResult {
+pub fn process_close(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResult {
     // Load accounts.
     let [signer, proof_info, system_program] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);

--- a/program/src/initialize.rs
+++ b/program/src/initialize.rs
@@ -19,10 +19,7 @@ use spl_token::state::Mint;
 use crate::utils::{create_pda, AccountDeserialize, Discriminator};
 
 /// Initialize sets up the ORE program to begin mining.
-pub fn process_initialize<'a, 'info>(
-    accounts: &'a [AccountInfo<'info>],
-    data: &[u8],
-) -> ProgramResult {
+pub fn process_initialize(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
     // Parse args.
     let args = InitializeArgs::try_from_bytes(data)?;
 
@@ -101,7 +98,7 @@ pub fn process_initialize<'a, 'info>(
             signer,
         )?;
         let mut bus_data = bus_infos[i].try_borrow_mut_data()?;
-        bus_data[0] = Bus::discriminator() as u8;
+        bus_data[0] = Bus::discriminator();
         let bus = Bus::try_from_bytes_mut(&mut bus_data)?;
         bus.id = i as u64;
         bus.rewards = 0;
@@ -119,7 +116,7 @@ pub fn process_initialize<'a, 'info>(
         signer,
     )?;
     let mut config_data = config_info.data.borrow_mut();
-    config_data[0] = Config::discriminator() as u8;
+    config_data[0] = Config::discriminator();
     let config = Config::try_from_bytes_mut(&mut config_data)?;
     config.base_reward_rate = INITIAL_BASE_REWARD_RATE;
     config.last_reset_at = 0;
@@ -136,7 +133,7 @@ pub fn process_initialize<'a, 'info>(
         signer,
     )?;
     let mut treasury_data = treasury_info.data.borrow_mut();
-    treasury_data[0] = Treasury::discriminator() as u8;
+    treasury_data[0] = Treasury::discriminator();
     drop(treasury_data);
 
     // Initialize mint.

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -27,7 +27,7 @@ use solana_program::{
 use crate::utils::AccountDeserialize;
 
 /// Mine validates hashes and increments a miner's collectable balance.
-pub fn process_mine<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
+pub fn process_mine(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
     // Parse args.
     let args = MineArgs::try_from_bytes(data)?;
 

--- a/program/src/open.rs
+++ b/program/src/open.rs
@@ -15,7 +15,7 @@ use solana_program::{
 use crate::utils::{create_pda, AccountDeserialize, Discriminator};
 
 /// Open creates a new proof account to track a miner's state.
-pub fn process_open<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
+pub fn process_open(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
     // Parse args.
     let args = OpenArgs::try_from_bytes(data)?;
 
@@ -47,7 +47,7 @@ pub fn process_open<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) 
     )?;
     let clock = Clock::get().or(Err(ProgramError::InvalidAccountData))?;
     let mut proof_data = proof_info.data.borrow_mut();
-    proof_data[0] = Proof::discriminator() as u8;
+    proof_data[0] = Proof::discriminator();
     let proof = Proof::try_from_bytes_mut(&mut proof_data)?;
     proof.authority = *signer.key;
     proof.balance = 0;

--- a/program/src/stake.rs
+++ b/program/src/stake.rs
@@ -8,7 +8,7 @@ use solana_program::{
 use crate::utils::AccountDeserialize;
 
 /// Stake deposits ORE into a proof account to earn multiplier.
-pub fn process_stake<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
+pub fn process_stake(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
     // Parse args.
     let args = StakeArgs::try_from_bytes(data)?;
     let amount = u64::from_le_bytes(args.amount);

--- a/program/src/update.rs
+++ b/program/src/update.rs
@@ -6,10 +6,7 @@ use solana_program::{
 use crate::utils::AccountDeserialize;
 
 /// Update changes the miner authority on a proof account.
-pub fn process_update<'a, 'info>(
-    accounts: &'a [AccountInfo<'info>],
-    _data: &[u8],
-) -> ProgramResult {
+pub fn process_update(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResult {
     // Load accounts.
     let [signer, miner_info, proof_info] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);

--- a/program/src/upgrade.rs
+++ b/program/src/upgrade.rs
@@ -7,10 +7,7 @@ use solana_program::{
 use spl_token::state::Mint;
 
 /// Upgrade allows a user to migrate a v1 token to a v2 token at a 1:1 exchange rate.
-pub fn process_upgrade<'a, 'info>(
-    accounts: &'a [AccountInfo<'info>],
-    data: &[u8],
-) -> ProgramResult {
+pub fn process_upgrade(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
     // Parse args
     let args = StakeArgs::try_from_bytes(data)?;
     let amount = u64::from_le_bytes(args.amount);
@@ -22,7 +19,7 @@ pub fn process_upgrade<'a, 'info>(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
     load_signer(signer)?;
-    load_token_account(beneficiary_info, Some(&signer.key), &MINT_ADDRESS, true)?;
+    load_token_account(beneficiary_info, Some(signer.key), &MINT_ADDRESS, true)?;
     load_mint(mint_info, MINT_ADDRESS, true)?;
     load_mint(mint_v1_info, MINT_V1_ADDRESS, true)?;
     load_token_account(sender_info, Some(signer.key), &MINT_V1_ADDRESS, true)?;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -97,7 +97,7 @@ macro_rules! impl_to_bytes {
 #[macro_export]
 macro_rules! impl_account_from_bytes {
     ($struct_name:ident) => {
-        impl crate::utils::AccountDeserialize for $struct_name {
+        impl $crate::AccountDeserialize for $struct_name {
             fn try_from_bytes(
                 data: &[u8],
             ) -> Result<&Self, solana_program::program_error::ProgramError> {


### PR DESCRIPTION
Hey,

Running cargo clippy (rust linter) and fixing raised issues.

```
cargo clippy --all-targets --all-features
```

<details>
  <summary>Warnings</summary>
  
```
orex> cargo clippy --all-targets --all-features
    Checking ore-utils v2.1.0 (/Users/orex/work/ore/utils)
warning: `crate` references the macro call's crate
   --> utils/src/lib.rs:100:14
    |
100 |         impl crate::utils::AccountDeserialize for $struct_name {
    |              ^^^^^ help: to reference the macro definition's crate, use: `$crate`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#crate_in_macro_def
    = note: `#[warn(clippy::crate_in_macro_def)]` on by default

warning: `ore-utils` (lib) generated 1 warning (run `cargo clippy --fix --lib -p ore-utils` to apply 1 suggestion)
    Checking ore-api v2.1.0 (/Users/orex/work/ore/api)
warning: `ore-utils` (lib test) generated 1 warning (1 duplicate)
warning: the following explicit lifetimes could be elided: 'a, 'info
  --> api/src/loaders.rs:15:20
   |
15 | pub fn load_signer<'a, 'info>(info: &'a AccountInfo<'info>) -> Result<(), ProgramError> {
   |                    ^^  ^^^^^         ^^             ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
15 - pub fn load_signer<'a, 'info>(info: &'a AccountInfo<'info>) -> Result<(), ProgramError> {
15 + pub fn load_signer(info: &AccountInfo<'_>) -> Result<(), ProgramError> {
   |

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> api/src/loaders.rs:30:17
   |
30 | pub fn load_bus<'a, 'info>(
   |                 ^^  ^^^^^
31 |     info: &'a AccountInfo<'info>,
   |            ^^             ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
30 ~ pub fn load_bus(
31 ~     info: &AccountInfo<'_>,
   |

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> api/src/loaders.rs:68:21
   |
68 | pub fn load_any_bus<'a, 'info>(
   |                     ^^  ^^^^^
69 |     info: &'a AccountInfo<'info>,
   |            ^^             ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
68 ~ pub fn load_any_bus(
69 ~     info: &AccountInfo<'_>,
   |

warning: casting to the same type is unnecessary (`u8` -> `u8`)
  --> api/src/loaders.rs:80:34
   |
80 |     if info.data.borrow()[0].ne(&(Bus::discriminator() as u8)) {
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `{ Bus::discriminator() }`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
   = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:101:20
    |
101 | pub fn load_config<'a, 'info>(
    |                    ^^  ^^^^^
102 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
101 ~ pub fn load_config(
102 ~     info: &AccountInfo<'_>,
    |

warning: casting to the same type is unnecessary (`u8` -> `u8`)
   --> api/src/loaders.rs:117:34
    |
117 |     if info.data.borrow()[0].ne(&(Config::discriminator() as u8)) {
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `{ Config::discriminator() }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:134:19
    |
134 | pub fn load_proof<'a, 'info>(
    |                   ^^  ^^^^^
135 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
134 ~ pub fn load_proof(
135 ~     info: &AccountInfo<'_>,
    |

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> api/src/loaders.rs:150:27
    |
150 |     if proof.authority.ne(&authority) {
    |                           ^^^^^^^^^^ help: change this to: `authority`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:167:30
    |
167 | pub fn load_proof_with_miner<'a, 'info>(
    |                              ^^  ^^^^^
168 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
167 ~ pub fn load_proof_with_miner(
168 ~     info: &AccountInfo<'_>,
    |

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> api/src/loaders.rs:183:23
    |
183 |     if proof.miner.ne(&miner) {
    |                       ^^^^^^ help: change this to: `miner`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:199:23
    |
199 | pub fn load_any_proof<'a, 'info>(
    |                       ^^  ^^^^^
200 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
199 ~ pub fn load_any_proof(
200 ~     info: &AccountInfo<'_>,
    |

warning: casting to the same type is unnecessary (`u8` -> `u8`)
   --> api/src/loaders.rs:211:34
    |
211 |     if info.data.borrow()[0].ne(&(Proof::discriminator() as u8)) {
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `{ Proof::discriminator() }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:228:22
    |
228 | pub fn load_treasury<'a, 'info>(
    |                      ^^  ^^^^^
229 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
228 ~ pub fn load_treasury(
229 ~     info: &AccountInfo<'_>,
    |

warning: casting to the same type is unnecessary (`u8` -> `u8`)
   --> api/src/loaders.rs:244:34
    |
244 |     if info.data.borrow()[0].ne(&(Treasury::discriminator() as u8)) {
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `{ Treasury::discriminator() }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:258:29
    |
258 | pub fn load_treasury_tokens<'a, 'info>(
    |                             ^^  ^^^^^
259 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
258 ~ pub fn load_treasury_tokens(
259 ~     info: &AccountInfo<'_>,
    |

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:275:18
    |
275 | pub fn load_mint<'a, 'info>(
    |                  ^^  ^^^^^
276 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
275 ~ pub fn load_mint(
276 ~     info: &AccountInfo<'_>,
    |

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:308:27
    |
308 | pub fn load_token_account<'a, 'info>(
    |                           ^^  ^^^^^
309 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
308 ~ pub fn load_token_account(
309 ~     info: &AccountInfo<'_>,
    |

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> api/src/loaders.rs:325:24
    |
325 |     if account.mint.ne(&mint) {
    |                        ^^^^^ help: change this to: `mint`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:345:31
    |
345 | pub fn load_uninitialized_pda<'a, 'info>(
    |                               ^^  ^^^^^
346 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
345 ~ pub fn load_uninitialized_pda(
346 ~     info: &AccountInfo<'_>,
    |

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:368:28
    |
368 | pub fn load_system_account<'a, 'info>(
    |                            ^^  ^^^^^
369 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
368 ~ pub fn load_system_account(
369 ~     info: &AccountInfo<'_>,
    |

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:390:20
    |
390 | pub fn load_sysvar<'a, 'info>(
    |                    ^^  ^^^^^
391 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
390 ~ pub fn load_sysvar(
391 ~     info: &AccountInfo<'_>,
    |

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:404:21
    |
404 | pub fn load_account<'a, 'info>(
    |                     ^^  ^^^^^
405 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
404 ~ pub fn load_account(
405 ~     info: &AccountInfo<'_>,
    |

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:423:21
    |
423 | pub fn load_program<'a, 'info>(
    |                     ^^  ^^^^^
424 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
423 ~ pub fn load_program(
424 ~     info: &AccountInfo<'_>,
    |

warning: the following explicit lifetimes could be elided: 'a, 'info
   --> api/src/loaders.rs:440:17
    |
440 | pub fn load_any<'a, 'info>(
    |                 ^^  ^^^^^
441 |     info: &'a AccountInfo<'info>,
    |            ^^             ^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
440 ~ pub fn load_any(
441 ~     info: &AccountInfo<'_>,
    |

warning: `ore-api` (lib test) generated 24 warnings (9 duplicates) (run `cargo clippy --fix --lib -p ore-api --tests` to apply 15 suggestions)
warning: `ore-api` (lib) generated 24 warnings (15 duplicates) (run `cargo clippy --fix --lib -p ore-api` to apply 9 suggestions)
    Checking ore-program v2.1.0 (/Users/orex/work/ore/program)
warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/claim.rs:10:22
   |
10 | pub fn process_claim<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
   |                      ^^  ^^^^^             ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
10 - pub fn process_claim<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
10 + pub fn process_claim(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
   |

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/close.rs:10:22
   |
10 | pub fn process_close<'a, 'info>(accounts: &'a [AccountInfo<'info>], _data: &[u8]) -> ProgramResult {
   |                      ^^  ^^^^^             ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
10 - pub fn process_close<'a, 'info>(accounts: &'a [AccountInfo<'info>], _data: &[u8]) -> ProgramResult {
10 + pub fn process_close(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResult {
   |

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/initialize.rs:22:27
   |
22 | pub fn process_initialize<'a, 'info>(
   |                           ^^  ^^^^^
23 |     accounts: &'a [AccountInfo<'info>],
   |                ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
22 ~ pub fn process_initialize(
23 ~     accounts: &[AccountInfo<'_>],
   |

warning: casting to the same type is unnecessary (`u8` -> `u8`)
   --> program/src/initialize.rs:104:23
    |
104 |         bus_data[0] = Bus::discriminator() as u8;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Bus::discriminator()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: casting to the same type is unnecessary (`u8` -> `u8`)
   --> program/src/initialize.rs:122:22
    |
122 |     config_data[0] = Config::discriminator() as u8;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Config::discriminator()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: casting to the same type is unnecessary (`u8` -> `u8`)
   --> program/src/initialize.rs:139:24
    |
139 |     treasury_data[0] = Treasury::discriminator() as u8;
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Treasury::discriminator()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/mine.rs:30:21
   |
30 | pub fn process_mine<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
   |                     ^^  ^^^^^             ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
30 - pub fn process_mine<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
30 + pub fn process_mine(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
   |

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/open.rs:18:21
   |
18 | pub fn process_open<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
   |                     ^^  ^^^^^             ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
18 - pub fn process_open<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
18 + pub fn process_open(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
   |

warning: casting to the same type is unnecessary (`u8` -> `u8`)
  --> program/src/open.rs:50:21
   |
50 |     proof_data[0] = Proof::discriminator() as u8;
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Proof::discriminator()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/reset.rs:16:22
   |
16 | pub fn process_reset<'a, 'info>(accounts: &'a [AccountInfo<'info>], _data: &[u8]) -> ProgramResult {
   |                      ^^  ^^^^^             ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
16 - pub fn process_reset<'a, 'info>(accounts: &'a [AccountInfo<'info>], _data: &[u8]) -> ProgramResult {
16 + pub fn process_reset(accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResult {
   |

warning: the loop variable `i` is only used to index `busses`
  --> program/src/reset.rs:61:14
   |
61 |     for i in 0..BUS_COUNT {
   |              ^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop
   = note: `#[warn(clippy::needless_range_loop)]` on by default
help: consider using an iterator
   |
61 |     for <item> in busses.iter().take(BUS_COUNT) {
   |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

warning: clamp-like pattern without using clamp function
   --> program/src/reset.rs:159:5
    |
159 |     new_rate_smoothed.max(1).min(BUS_EPOCH_REWARDS)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `new_rate_smoothed.clamp(1, BUS_EPOCH_REWARDS)`
    |
    = note: clamp will panic if max < min
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp
    = note: `#[warn(clippy::manual_clamp)]` on by default

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/stake.rs:11:22
   |
11 | pub fn process_stake<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
   |                      ^^  ^^^^^             ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
11 - pub fn process_stake<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) -> ProgramResult {
11 + pub fn process_stake(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
   |

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/update.rs:9:23
   |
9  | pub fn process_update<'a, 'info>(
   |                       ^^  ^^^^^
10 |     accounts: &'a [AccountInfo<'info>],
   |                ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
9  ~ pub fn process_update(
10 ~     accounts: &[AccountInfo<'_>],
   |

warning: the following explicit lifetimes could be elided: 'a, 'info
  --> program/src/upgrade.rs:10:24
   |
10 | pub fn process_upgrade<'a, 'info>(
   |                        ^^  ^^^^^
11 |     accounts: &'a [AccountInfo<'info>],
   |                ^^              ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
10 ~ pub fn process_upgrade(
11 ~     accounts: &[AccountInfo<'_>],
   |

warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> program/src/upgrade.rs:25:47
   |
25 |     load_token_account(beneficiary_info, Some(&signer.key), &MINT_ADDRESS, true)?;
   |                                               ^^^^^^^^^^^ help: change this to: `signer.key`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: `ore-program` (lib) generated 16 warnings (3 duplicates) (run `cargo clippy --fix --lib -p ore-program` to apply 11 suggestions)
warning: `ore-program` (lib test) generated 16 warnings (13 duplicates) (run `cargo clippy --fix --lib -p ore-program --tests` to apply 3 suggestions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.15s
```
</details>
