### PR TITLE
add post balance to MineEvent log

### DIFF
--- a/api/src/event.rs
+++ b/api/src/event.rs
@@ -8,6 +8,7 @@ pub struct MineEvent {
     pub difficulty: u64,
     pub reward: u64,
     pub timing: i64,
+    pub balance: u64,
 }
 
 impl_to_bytes!(MineEvent);

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -198,6 +198,7 @@ pub fn process_mine<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) 
             difficulty: difficulty as u64,
             reward: reward_actual,
             timing: t.saturating_sub(t_liveness),
+            balance: proof.balance,
         }
         .to_bytes(),
     );


### PR DESCRIPTION
#78 

Changes the `MineEvent` struct to include the balance. 