### PR TITLE
bump epoch to 2 minutes

### DIFF
--- a/api/src/consts.rs
+++ b/api/src/consts.rs
@@ -34,7 +34,7 @@ pub const ONE_ORE: u64 = 10u64.pow(TOKEN_DECIMALS as u32);
 pub const ONE_MINUTE: i64 = 60;
 
 /// The number of minutes in a program epoch.
-pub const EPOCH_MINUTES: i64 = 1;
+pub const EPOCH_MINUTES: i64 = 2;
 
 /// The duration of a program epoch, in seconds.
 pub const EPOCH_DURATION: i64 = ONE_MINUTE * EPOCH_MINUTES;
@@ -46,7 +46,7 @@ pub const MAX_SUPPLY: u64 = ONE_ORE * 21_000_000;
 pub const TARGET_EPOCH_REWARDS: u64 = ONE_ORE * EPOCH_MINUTES as u64;
 
 /// The maximum quantity of ORE that can be mined per epoch.
-/// Inflation rate ≈ 1 ORE / min (min 0, max 8)
+/// Inflation target ≈ 1 ORE / min
 pub const MAX_EPOCH_REWARDS: u64 = TARGET_EPOCH_REWARDS * BUS_COUNT as u64;
 
 /// The quantity of ORE each bus is allowed to issue per epoch.

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -160,7 +160,7 @@ pub fn process_mine<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) 
 
     // Limit payout amount to whatever is left in the bus.
     //
-    // Busses are limited to distributing 1 ORE per epoch. This is also the maximum amount a miner can earn
+    // Busses are limited to distributing 1 ORE per epoch. This is also the maximum amount that will be paid out
     // for any given hash.
     let reward_actual = reward.min(bus.rewards).min(ONE_ORE);
 

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -160,9 +160,9 @@ pub fn process_mine<'a, 'info>(accounts: &'a [AccountInfo<'info>], data: &[u8]) 
 
     // Limit payout amount to whatever is left in the bus.
     //
-    // Busses are limited to distributing 1 ORE per epoch. This is the maximum amount a miner can earn
+    // Busses are limited to distributing 1 ORE per epoch. This is also the maximum amount a miner can earn
     // for any given hash.
-    let reward_actual = reward.min(bus.rewards);
+    let reward_actual = reward.min(bus.rewards).min(ONE_ORE);
 
     // Update balances.
     //


### PR DESCRIPTION
- There is currently a lot of variance in the reward rate. 
- This patch increases the epoch times to collect more datapoints for the reward rate adjustment and reduce variance.
- Bumps epoch minutes to 2
- Hardcaps payout amount to 1 ORE per hash