### PR TITLE
Deprecate legacy staking

### DIFF
--- a/api/src/instruction.rs
+++ b/api/src/instruction.rs
@@ -9,6 +9,7 @@ pub enum OreInstruction {
     Mine = 2,
     Open = 3,
     Reset = 4,
+    #[deprecated(since = "2.3.0", note = "Please stake with boosts program")]
     Stake = 5,
     Update = 6,
     Upgrade = 7,
@@ -44,6 +45,7 @@ pub struct Open {
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct Reset {}
 
+#[deprecated(since = "2.3.0", note = "Please stake with boosts program")]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct Stake {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod consts;
 pub mod error;
 pub mod event;
+#[allow(deprecated)]
 pub mod instruction;
 pub mod loaders;
 pub mod sdk;

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -124,8 +124,10 @@ pub fn reset(signer: Pubkey) -> Instruction {
 }
 
 /// Build a stake instruction.
+#[deprecated(since = "2.3.0", note = "Please stake with boosts program")]
 pub fn stake(signer: Pubkey, sender: Pubkey, amount: u64) -> Instruction {
     let proof = proof_pda(signer).0;
+    #[allow(deprecated)]
     Instruction {
         program_id: crate::ID,
         accounts: vec![

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -34,6 +34,7 @@ pub fn process_instruction(
         OreInstruction::Mine => process_mine(accounts, data)?,
         OreInstruction::Open => process_open(accounts, data)?,
         OreInstruction::Reset => process_reset(accounts, data)?,
+        #[allow(deprecated)]
         OreInstruction::Stake => process_stake(accounts, data)?,
         OreInstruction::Update => process_update(accounts, data)?,
         OreInstruction::Upgrade => process_upgrade(accounts, data)?,

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -95,28 +95,6 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
         .checked_mul(2u64.checked_pow(normalized_difficulty).unwrap())
         .unwrap();
 
-    // Apply staking multiplier.
-    //
-    // If user has greater than or equal to the max stake on the network, they receive 2x multiplier.
-    // Any stake less than this will receives between 1x and 2x multipler. The multipler is only active
-    // if the miner's last stake deposit was more than one minute ago to protect against flash loan attacks.
-    if proof.balance.gt(&0) && proof.last_stake_at.saturating_add(ONE_MINUTE).lt(&t) {
-        // Calculate staking reward.
-        if config.top_balance.gt(&0) {
-            let staking_reward = (reward as u128)
-                .checked_mul(proof.balance.min(config.top_balance) as u128)
-                .unwrap()
-                .checked_div(config.top_balance as u128)
-                .unwrap() as u64;
-            reward = reward.checked_add(staking_reward).unwrap();
-        }
-
-        // Update bus stake tracker.
-        if proof.balance.gt(&bus.top_balance) {
-            bus.top_balance = proof.balance;
-        }
-    }
-
     // Apply boosts.
     //
     // Boosts are staking incentives that can multiply a miner's rewards. Up to 3 boosts can be applied

--- a/program/src/stake.rs
+++ b/program/src/stake.rs
@@ -1,44 +1,6 @@
-use ore_api::prelude::*;
 use steel::*;
 
 /// Stake deposits ORE into a proof account to earn multiplier.
-pub fn process_stake(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
-    // Parse args.
-    let args = Stake::try_from_bytes(data)?;
-    let amount = u64::from_le_bytes(args.amount);
-
-    // Load accounts.
-    let [signer_info, proof_info, sender_info, treasury_tokens_info, token_program] = accounts
-    else {
-        return Err(ProgramError::NotEnoughAccountKeys);
-    };
-    signer_info.is_signer()?;
-    let proof = proof_info
-        .to_account_mut::<Proof>(&ore_api::ID)?
-        .check_mut(|p| p.authority == *signer_info.key)?;
-    sender_info
-        .is_writable()?
-        .to_token_account()?
-        .check(|t| t.owner == *signer_info.key)?
-        .check(|t| t.mint == MINT_ADDRESS)?;
-    treasury_tokens_info.is_writable()?.is_treasury_tokens()?;
-    token_program.is_program(&spl_token::ID)?;
-
-    // Update the proof balance.
-    proof.balance = proof.balance.checked_add(amount).unwrap();
-
-    // Update deposit timestamp.
-    let clock = Clock::get()?;
-    proof.last_stake_at = clock.unix_timestamp;
-
-    // Transfer tokens from signer to treasury.
-    transfer(
-        signer_info,
-        sender_info,
-        treasury_tokens_info,
-        token_program,
-        amount,
-    )?;
-
-    Ok(())
+pub fn process_stake(_accounts: &[AccountInfo<'_>], _data: &[u8]) -> ProgramResult {
+    panic!("This instruction has been deprecated.");
 }

--- a/program/src/upgrade.rs
+++ b/program/src/upgrade.rs
@@ -4,7 +4,7 @@ use steel::*;
 /// Upgrade allows a user to migrate a v1 token to a v2 token at a 1:1 exchange rate.
 pub fn process_upgrade(accounts: &[AccountInfo<'_>], data: &[u8]) -> ProgramResult {
     // Parse args
-    let args = Stake::try_from_bytes(data)?;
+    let args = Upgrade::try_from_bytes(data)?;
     let amount = u64::from_le_bytes(args.amount);
 
     // Load accounts


### PR DESCRIPTION
- Adds deprecated flag to `Stake` args and instruction.
- Throws a panic in the stake implementation.
- Future version can remove these instructions/args entirely.