### PR TITLE
Increase epoch duration to 10 min

### DIFF
--- a/api/src/consts.rs
+++ b/api/src/consts.rs
@@ -34,7 +34,7 @@ pub const ONE_ORE: u64 = 10u64.pow(TOKEN_DECIMALS as u32);
 pub const ONE_MINUTE: i64 = 60;
 
 /// The number of minutes in a program epoch.
-pub const EPOCH_MINUTES: i64 = 5;
+pub const EPOCH_MINUTES: i64 = 10;
 
 /// The duration of a program epoch, in seconds.
 pub const EPOCH_DURATION: i64 = ONE_MINUTE * EPOCH_MINUTES;


### PR DESCRIPTION
With global boost rotations, the epoch rewards are more volatile. Increasing epoch duration would gather more data for smoother reward rate updates. 