### PR TITLE
Remove boost lock constraint

### DIFF
--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -105,9 +105,8 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
             .assert(|r| r.boost == *boost_info.key)?
             .assert(|r| r.ts == proof.last_hash_at)?;
 
-        // Apply multiplier if boost is unlocked and not expired.
-        if boost.expires_at > t && boost.locked == 0
-        {
+        // Apply multiplier if boost is not expired.
+        if boost.expires_at > t {
             boost_reward = (base_reward as u128)
                 .checked_mul(boost.multiplier as u128)
                 .unwrap()

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -98,21 +98,21 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let mut boost_reward = 0;
     if let [boost_info, _boost_proof_info, reservation_info] = optional_accounts {
         // Load boost accounts.
-        let boost = boost_info
-            .as_account::<Boost>(&ore_boost_api::ID)?
-            .assert(|b| b.expires_at > t)?;
+        let boost = boost_info.as_account::<Boost>(&ore_boost_api::ID)?;
         reservation_info
             .as_account::<Reservation>(&ore_boost_api::ID)?
             .assert(|r| r.authority == *proof_info.key)?
             .assert(|r| r.boost == *boost_info.key)?
             .assert(|r| r.ts == proof.last_hash_at)?;
 
-        // Apply multiplier.
-        boost_reward = (base_reward as u128)
+        // Apply multiplier if boost is not expired.
+        if boost.expires_at > t {
+            boost_reward = (base_reward as u128)
                 .checked_mul(boost.multiplier as u128)
                 .unwrap()
                 .checked_div(BOOST_DENOMINATOR as u128)
                 .unwrap() as u64;
+        }
     }
 
     // Apply liveness penalty.

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -98,21 +98,21 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     let mut boost_reward = 0;
     if let [boost_info, _boost_proof_info, reservation_info] = optional_accounts {
         // Load boost accounts.
-        let boost = boost_info.as_account::<Boost>(&ore_boost_api::ID)?;
+        let boost = boost_info
+            .as_account::<Boost>(&ore_boost_api::ID)?
+            .assert(|b| b.expires_at > t)?;
         reservation_info
             .as_account::<Reservation>(&ore_boost_api::ID)?
             .assert(|r| r.authority == *proof_info.key)?
             .assert(|r| r.boost == *boost_info.key)?
             .assert(|r| r.ts == proof.last_hash_at)?;
 
-        // Apply multiplier if boost is not expired.
-        if boost.expires_at > t {
-            boost_reward = (base_reward as u128)
+        // Apply multiplier.
+        boost_reward = (base_reward as u128)
                 .checked_mul(boost.multiplier as u128)
                 .unwrap()
                 .checked_div(BOOST_DENOMINATOR as u128)
                 .unwrap() as u64;
-        }
     }
 
     // Apply liveness penalty.


### PR DESCRIPTION
- The boost should be able to be used while checkpoint is ongoing. 
- All rewards accrue in the boost proof and are claimed at the start of the checkpoint. 
- If a checkpoint takes longer than expected (due to error), the rewards can continue accruing the stakers in the boost proof account and be distributed on the next checkpoint when the cranking bots recover. 