### PR TITLE
Make boosts mandatory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "ore-api"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -1323,11 +1323,11 @@ dependencies = [
 
 [[package]]
 name = "ore-program"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "drillx",
  "mpl-token-metadata",
- "ore-api 3.4.0",
+ "ore-api 3.5.0",
  "ore-boost-api 3.0.0",
  "rand 0.8.5",
  "solana-program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["api", "program"]
 
 [workspace.package]
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://ore.supply"

--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -56,22 +56,21 @@ pub fn mine(
     authority: Pubkey,
     bus: Pubkey,
     solution: Solution,
-    boost_keys: Option<[Pubkey; 2]>,
+    boost: Pubkey,
+    boost_config: Pubkey,
 ) -> Instruction {
     let proof = proof_pda(authority).0;
-    let mut accounts = vec![
+    let accounts = vec![
         AccountMeta::new(signer, true),
         AccountMeta::new(bus, false),
         AccountMeta::new_readonly(CONFIG_ADDRESS, false),
         AccountMeta::new(proof, false),
         AccountMeta::new_readonly(sysvar::instructions::ID, false),
         AccountMeta::new_readonly(sysvar::slot_hashes::ID, false),
+        AccountMeta::new_readonly(boost, false),
+        AccountMeta::new(proof_pda(boost).0, false),
+        AccountMeta::new_readonly(boost_config, false),
     ];
-    if let Some([boost_address, boost_config_address]) = boost_keys {
-        accounts.push(AccountMeta::new_readonly(boost_address, false));
-        accounts.push(AccountMeta::new(proof_pda(boost_address).0, false));
-        accounts.push(AccountMeta::new_readonly(boost_config_address, false));
-    }
     Instruction {
         program_id: crate::ID,
         accounts,

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -34,7 +34,7 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
         .is_config()?
         .as_account::<Config>(&ore_api::ID)?
         .assert_err(
-            |c| c.last_reset_at.saturating_add(EPOCH_DURATION) > t,
+            |c| t < c.last_reset_at + EPOCH_DURATION,
             OreError::NeedsReset.into(),
         )?;
     let proof = proof_info

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -22,8 +22,9 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     // Load accounts.
     let clock = Clock::get()?;
     let t: i64 = clock.unix_timestamp;
-    let [signer_info, bus_info, config_info, proof_info, instructions_sysvar, slot_hashes_sysvar, boost_info, boost_proof_info, boost_config_info] =
-        accounts
+    let (required_accounts, boost_accounts) = accounts.split_at(6);
+    let [signer_info, bus_info, config_info, proof_info, instructions_sysvar, slot_hashes_sysvar] =
+        required_accounts
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
@@ -46,6 +47,9 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     slot_hashes_sysvar.is_sysvar(&sysvar::slot_hashes::ID)?;
 
     // Load boost accounts.
+    let [boost_info, boost_proof_info, boost_config_info] = boost_accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
     let boost = boost_info.as_account::<Boost>(&ore_boost_api::ID)?;
     boost_config_info
         .as_account::<BoostConfig>(&ore_boost_api::ID)?

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -54,7 +54,7 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     boost_config_info
         .as_account::<BoostConfig>(&ore_boost_api::ID)?
         .assert(|c| c.current == *boost_info.key)?
-        .assert(|c| clock.unix_timestamp < c.ts + ROTATION_DURATION)?;
+        .assert(|c| t < c.ts + ROTATION_DURATION)?;
     let boost_proof = boost_proof_info
         .as_account_mut::<Proof>(&ore_api::ID)?
         .assert_mut(|p| p.authority == *boost_info.key)?;

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -47,7 +47,7 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
 
     // Load boost accounts.
     let boost = boost_info.as_account::<Boost>(&ore_boost_api::ID)?;
-    let boost_config = boost_config_info
+    boost_config_info
         .as_account::<BoostConfig>(&ore_boost_api::ID)?
         .assert(|c| c.current == *boost_info.key)?
         .assert(|c| clock.unix_timestamp < c.ts + ROTATION_DURATION)?;


### PR DESCRIPTION
Pool operators with significant market share of hashpower can influence staker yields by not submitting boosts they don't like. This is generally a -EV play since the pool misses out on the multiplier rewards, but it can create variability in the staker yields. By making boosts mandatory, all mining transaction that do not pass in the currently active boost would be automatically failed.

This change also prevents the scenario where a pool operator with significant hashpower could "turn off" boosts, thereby cutting off staking yield. If a pool operator attempted to opt out of boosts, this change would kick them off the network and mining rewards would go to remaining miners. 