### PR TITLE
Simplify boost accounting

### DIFF
--- a/api/src/sdk.rs
+++ b/api/src/sdk.rs
@@ -56,22 +56,21 @@ pub fn mine(
     authority: Pubkey,
     bus: Pubkey,
     solution: Solution,
-    boost_keys: Option<[Pubkey; 2]>,
+    boost: Pubkey,
+    boost_config: Pubkey,
 ) -> Instruction {
     let proof = proof_pda(authority).0;
-    let mut accounts = vec![
+    let accounts = vec![
         AccountMeta::new(signer, true),
         AccountMeta::new(bus, false),
         AccountMeta::new_readonly(CONFIG_ADDRESS, false),
         AccountMeta::new(proof, false),
         AccountMeta::new_readonly(sysvar::instructions::ID, false),
         AccountMeta::new_readonly(sysvar::slot_hashes::ID, false),
+        AccountMeta::new_readonly(boost, false),
+        AccountMeta::new(proof_pda(boost).0, false),
+        AccountMeta::new_readonly(boost_config, false),
     ];
-    if let Some([boost_address, boost_config_address]) = boost_keys {
-        accounts.push(AccountMeta::new_readonly(boost_address, false));
-        accounts.push(AccountMeta::new(proof_pda(boost_address).0, false));
-        accounts.push(AccountMeta::new_readonly(boost_config_address, false));
-    }
     Instruction {
         program_id: crate::ID,
         accounts,

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -139,8 +139,8 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
         .min(bus.rewards)
         .min(config.target_emmissions_rate);
 
-    // Calculate how much of the reward goes to stakers and how much goes to the miner.
-    assert!(boost.multiplier <= DENOMINATOR_MULTIPLIER);
+    // Calculate how much of the net reward goes to the miner and how much goes to stakers.
+    assert!(boost.multiplier <= DENOMINATOR_MULTIPLIER / 2);
     let net_boost_reward =
         (net_reward as u128 * boost.multiplier as u128 / DENOMINATOR_MULTIPLIER as u128) as u64;
     let net_miner_reward = net_reward - net_boost_reward;
@@ -153,10 +153,8 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     bus.rewards -= net_reward;
 
     // Update staker balances.
-    if net_boost_reward > 0 {
-        boost_proof.balance += net_boost_reward;
-        boost_proof.total_rewards += net_boost_reward;
-    }
+    boost_proof.balance += net_boost_reward;
+    boost_proof.total_rewards += net_boost_reward;
 
     // Update miner balances.
     proof.balance += net_miner_reward;

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -154,6 +154,9 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     };
     let net_miner_reward = net_reward - net_boost_reward;
 
+    // Sanity check the rewards.
+    assert_eq!(net_reward, net_miner_reward + net_boost_reward);
+
     // Update bus balances.
     //
     // We track the theoretical rewards that would have been paid out ignoring the bus limit, so the
@@ -184,9 +187,6 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     proof.last_hash_at = t.max(t_target);
     proof.total_hashes += 1;
     proof.total_rewards += net_miner_reward;
-
-    // Sanity check the rewards.
-    assert_eq!(net_miner_reward + net_boost_reward, net_reward);
 
     // Log data.
     //

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -22,8 +22,9 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     // Load accounts.
     let clock = Clock::get()?;
     let t: i64 = clock.unix_timestamp;
-    let [signer_info, bus_info, config_info, proof_info, instructions_sysvar, slot_hashes_sysvar, boost_info, boost_proof_info, boost_config_info] =
-        accounts
+    let (required_accounts, boost_accounts) = accounts.split_at(6);
+    let [signer_info, bus_info, config_info, proof_info, instructions_sysvar, slot_hashes_sysvar] =
+        required_accounts
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
@@ -46,6 +47,9 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     slot_hashes_sysvar.is_sysvar(&sysvar::slot_hashes::ID)?;
 
     // Load boost accounts.
+    let [boost_info, boost_proof_info, boost_config_info] = boost_accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
     let boost = boost_info.as_account::<Boost>(&ore_boost_api::ID)?;
     boost_config_info
         .as_account::<BoostConfig>(&ore_boost_api::ID)?

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -54,7 +54,7 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     boost_config_info
         .as_account::<BoostConfig>(&ore_boost_api::ID)?
         .assert(|c| c.current == *boost_info.key)?
-        .assert(|c| clock.unix_timestamp < c.ts + ROTATION_DURATION)?;
+        .assert(|c| t < c.ts + ROTATION_DURATION)?;
     let boost_proof = boost_proof_info
         .as_account_mut::<Proof>(&ore_api::ID)?
         .assert_mut(|p| p.authority == *boost_info.key)?;

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -69,9 +69,9 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     //
     // Miners are rate limited to approximately 1 hash per minute. If a miner attempts to submit
     // solutions more frequently than this, reject with an error.
-    let t_target = proof.last_hash_at.saturating_add(ONE_MINUTE);
-    let t_spam = t_target.saturating_sub(TOLERANCE);
-    if t.lt(&t_spam) {
+    let t_target = proof.last_hash_at + ONE_MINUTE;
+    let t_spam = t_target - TOLERANCE;
+    if t < t_spam {
         return Err(OreError::Spam.into());
     }
 
@@ -90,46 +90,27 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     // minimum required difficulty, we reject it with an error.
     let hash = solution.to_hash();
     let difficulty = hash.difficulty();
-    if difficulty.lt(&(config.min_difficulty as u32)) {
+    if difficulty < config.min_difficulty as u32 {
         return Err(OreError::HashTooEasy.into());
     }
 
-    // Normalize the difficulty and calculate the reward amount.
+    // Normalize the difficulty and calculate the gross reward amount.
     //
     // The reward doubles for every bit of difficulty (leading zeros) on the hash. We use the normalized
     // difficulty so the minimum accepted difficulty pays out at the base reward rate.
-    let normalized_difficulty = difficulty
-        .checked_sub(config.min_difficulty as u32)
-        .unwrap();
-    let base_reward = config
-        .base_reward_rate
-        .checked_mul(2u64.checked_pow(normalized_difficulty).unwrap())
-        .unwrap();
-
-    // Apply boosts.
-    //
-    // Boosts are staking incentives that can multiply a miner's rewards. The boost rewards are
-    // split between the miner and staker.
-    let mut boost_reward = 0;
-    if t < boost.expires_at {
-        boost_reward = (base_reward as u128)
-            .checked_mul(boost.multiplier as u128)
-            .unwrap()
-            .checked_div(DENOMINATOR_MULTIPLIER as u128)
-            .unwrap() as u64;
-    }
+    let normalized_difficulty = difficulty - config.min_difficulty as u32;
+    let gross_reward = config.base_reward_rate * 2u64.checked_pow(normalized_difficulty).unwrap();
 
     // Apply liveness penalty.
     //
-    // The liveness penalty exists to ensure there is no "invisible" hashpower on the network. It
-    // should not be possible to spend ~1 hour on a given challenge and submit a hash with a large
-    // difficulty value to earn an outsized reward.
+    // The liveness penalty exists to ensure there is no "dark" hashpower on the network. It
+    // should not be possible to spend an excessively long time on a given challenge and submit a hash
+    // with a large difficulty score to earn an outsized reward.
     //
-    // The penalty works by halving the reward amount for every minute late the solution has been submitted.
+    // The liveness penalty works by halving the reward amount for every minute a solution has been submitted late.
     // This ultimately drives the reward to zero given enough time (10-20 minutes).
-    let gross_reward = base_reward.checked_add(boost_reward).unwrap();
     let mut gross_penalized_reward = gross_reward;
-    let t_liveness = t_target.saturating_add(TOLERANCE);
+    let t_liveness = t_target + TOLERANCE;
     if t > t_liveness {
         // Halve the reward for every minute late.
         let secs_late = t.saturating_sub(t_target) as u64;
@@ -152,64 +133,33 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
 
     // Apply bus limit.
     //
-    // Busses are limited to distributing 1 ORE per epoch. The payout amount must be capped to whatever is
-    // left in the selected bus. This limits the maximum amount that will be paid out for any given hash to 1 ORE.
-    let net_reward = gross_penalized_reward.min(bus.rewards).min(ONE_ORE);
+    // Busses are limited to distributing the target emissions rate per epoch. The payout amount must be capped to whatever is
+    // left in the selected bus. This limits the maximum amount that will be paid out for any given hash to the target emissions rate.
+    let net_reward = gross_penalized_reward
+        .min(bus.rewards)
+        .min(config.target_emmissions_rate);
 
-    // Scale the base and boost rewards to account for penalties.
-    let net_base_reward = if gross_reward > 0 {
-        (net_reward as u128)
-            .checked_mul(base_reward as u128)
-            .unwrap()
-            .checked_div(gross_reward as u128)
-            .unwrap() as u64
-    } else {
-        0
-    };
-    let net_boost_reward = net_reward.checked_sub(net_base_reward).unwrap();
-
-    // Split the boost rewards between miner and staker.
-    let net_staker_boost_reward = net_boost_reward.checked_div(2).unwrap();
-    let net_miner_boost_reward = net_boost_reward
-        .checked_sub(net_staker_boost_reward)
-        .unwrap();
-    let net_miner_reward = net_base_reward.checked_add(net_miner_boost_reward).unwrap();
-
-    // Checksum on rewards. Should never fail.
-    assert!(
-        net_reward
-            == net_base_reward
-                .checked_add(net_miner_boost_reward)
-                .unwrap()
-                .checked_add(net_staker_boost_reward)
-                .unwrap(),
-        "Rewards checksum failed"
-    );
+    // Calculate how much of the reward goes to stakers and how much goes to the miner.
+    assert!(boost.multiplier <= DENOMINATOR_MULTIPLIER);
+    let net_boost_reward =
+        (net_reward as u128 * boost.multiplier as u128 / DENOMINATOR_MULTIPLIER as u128) as u64;
+    let net_miner_reward = net_reward - net_boost_reward;
 
     // Update bus balances.
     //
     // We track the theoretical rewards that would have been paid out ignoring the bus limit, so the
     // base reward rate will be updated to account for the real hashpower on the network.
-    bus.theoretical_rewards = bus
-        .theoretical_rewards
-        .checked_add(gross_penalized_reward)
-        .unwrap();
-    bus.rewards = bus.rewards.checked_sub(net_reward).unwrap();
-
-    // Update miner balances.
-    proof.balance = proof.balance.checked_add(net_miner_reward).unwrap();
+    bus.theoretical_rewards += gross_penalized_reward;
+    bus.rewards -= net_reward;
 
     // Update staker balances.
-    if net_staker_boost_reward > 0 {
-        boost_proof.balance = boost_proof
-            .balance
-            .checked_add(net_staker_boost_reward)
-            .unwrap();
-        boost_proof.total_rewards = boost_proof
-            .total_rewards
-            .checked_add(net_staker_boost_reward)
-            .unwrap();
+    if net_boost_reward > 0 {
+        boost_proof.balance += net_boost_reward;
+        boost_proof.total_rewards += net_boost_reward;
     }
+
+    // Update miner balances.
+    proof.balance += net_miner_reward;
 
     // Hash a recent slot hash into the next challenge to prevent pre-mining attacks.
     //
@@ -225,8 +175,8 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
     // Update stats.
     let prev_last_hash_at = proof.last_hash_at;
     proof.last_hash_at = t.max(t_target);
-    proof.total_hashes = proof.total_hashes.saturating_add(1);
-    proof.total_rewards = proof.total_rewards.saturating_add(net_miner_reward);
+    proof.total_hashes += 1;
+    proof.total_rewards += net_miner_reward;
 
     // Log data.
     //
@@ -236,11 +186,11 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
         balance: proof.balance,
         difficulty: difficulty as u64,
         last_hash_at: prev_last_hash_at,
-        timing: t.saturating_sub(t_liveness),
+        timing: t - t_liveness,
         net_reward,
-        net_base_reward,
-        net_miner_boost_reward,
-        net_staker_boost_reward,
+        net_base_reward: net_miner_reward,
+        net_miner_boost_reward: 0,
+        net_staker_boost_reward: net_boost_reward,
     }
     .log_return();
 

--- a/program/src/mine.rs
+++ b/program/src/mine.rs
@@ -47,7 +47,7 @@ pub fn process_mine(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
 
     // Load boost accounts.
     let boost = boost_info.as_account::<Boost>(&ore_boost_api::ID)?;
-    let boost_config = boost_config_info
+    boost_config_info
         .as_account::<BoostConfig>(&ore_boost_api::ID)?
         .assert(|c| c.current == *boost_info.key)?
         .assert(|c| clock.unix_timestamp < c.ts + ROTATION_DURATION)?;


### PR DESCRIPTION
To simplify boost accounting and smooth out reward rate adjustments, this PR changes the boost accounting model from a "multiplier" system to a "percentage" based system. In the new model, the boost reward would simply be configured as a percentage of the net reward and stakers would simply earn 100% of the boost reward. This change is predicated on boosts being mandatory for all miners so that miners would not be able to opt out of paying towards boosts. Upon rollout, the active boosts multipliers would be converted to their respective percentage versions (eg. 5x would convert to ~40%, 2.5x would convert to ~35%, and 1x would convert to 25%). The boost rotation system would remain unchanged. 