### PR TITLE
Pre-select top miner on round reset

### DIFF
--- a/api/src/event.rs
+++ b/api/src/event.rs
@@ -24,8 +24,8 @@ pub struct ResetEvent {
     /// The winning square of the round.
     pub winning_square: u64,
 
-    /// The top miner of the round.
-    pub top_miner: Pubkey,
+    /// The top miner sample used to determine the top miner of the round.
+    pub top_miner_sample: u64,
 
     /// The number of miners on the winning square.
     pub num_winners: u64,

--- a/api/src/state/round.rs
+++ b/api/src/state/round.rs
@@ -43,6 +43,9 @@ pub struct Round {
 
     /// The total amount of SOL won by miners for the round.
     pub total_winnings: u64,
+
+    /// A sample value used to determine the top miner.
+    pub top_miner_sample: u64,
 }
 
 impl Round {

--- a/program/src/checkpoint.rs
+++ b/program/src/checkpoint.rs
@@ -96,9 +96,8 @@ pub fn process_checkpoint(accounts: &[AccountInfo<'_>], _data: &[u8]) -> Program
                 );
             } else {
                 // If round is not split, payout to the top miner.
-                let top_miner_sample = round.top_miner_sample(r, winning_square);
-                if top_miner_sample >= miner.cumulative[winning_square]
-                    && top_miner_sample
+                if round.top_miner_sample >= miner.cumulative[winning_square]
+                    && round.top_miner_sample
                         < miner.cumulative[winning_square] + miner.deployed[winning_square]
                 {
                     rewards_ore = round.top_miner_reward;


### PR DESCRIPTION
There is currently a small probability where no miners are eligible to claim the top miner reward in each non-splitting round. This change sets the top miner example on each round reset, deterministically setting a top miner for each round, whom can receive the top miner reward on checkpoint.